### PR TITLE
Ensure contract addresses are always the same

### DIFF
--- a/deployment/deploy.js
+++ b/deployment/deploy.js
@@ -4,10 +4,23 @@ const {
   TrivialAppArtifact,
 } = require("@statechannels/nitro-protocol").ContractArtifacts;
 
-const { GanacheDeployer } = require("@statechannels/devtools");
+const {
+  GanacheDeployer,
+  ETHERLIME_ACCOUNTS,
+} = require("@statechannels/devtools");
 
 const deploy = async () => {
-  const deployer = new GanacheDeployer(Number(process.env.GANACHE_PORT));
+  const deployer = new GanacheDeployer(
+    Number(process.env.GANACHE_PORT),
+    ETHERLIME_ACCOUNTS[0].privateKey
+  );
+
+  const txCount = await deployer.etherlimeDeployer.signer.getTransactionCount();
+  if (txCount > 0) {
+    throw new Error(
+      `The tutorial requires a fresh blockchain in order for test assertions to be accurate. Try killing anything running on port ${process.env.GANACHE_PORT} and trying again`
+    );
+  }
 
   const NITRO_ADJUDICATOR_ADDRESS = await deployer.deploy(
     NitroAdjudicatorArtifact

--- a/jest/contract-test-setup.ts
+++ b/jest/contract-test-setup.ts
@@ -12,5 +12,24 @@ export default async function setup() {
   const deployedArtifacts = await deploy();
 
   process.env = { ...process.env, ...deployedArtifacts };
+
+  if (
+    process.env.ETH_ASSET_HOLDER_ADDRESS !==
+    "0x9eD274314f0fB37837346C425D3cF28d89ca9599"
+  ) {
+    throw new Error(
+      `ETH_ASSET_HOLDER not at expected address (instead at ${process.env.ETH_ASSET_HOLDER_ADDRESS}`
+    );
+  }
+
+  if (
+    process.env.NITRO_ADJUDICATOR_ADDRESS !==
+    "0xc9707E1e496C12f1Fa83AFbbA8735DA697cdBf64"
+  ) {
+    throw new Error(
+      `NITRO_ADJUDICATOR not at expected address (instead at ${process.env.NITRO_ADJUDICATOR_ADDRESS})`
+    );
+  }
+
   (global as any).__GANACHE_SERVER__ = ganacheServer;
 }

--- a/jest/contract-test-teardown.ts
+++ b/jest/contract-test-teardown.ts
@@ -1,3 +1,5 @@
+import { GanacheServer } from "@statechannels/devtools";
+
 export default async function teardown() {
-  await (global as any).__GANACHE_SERVER__.close();
+  await ((global as any).__GANACHE_SERVER__ as GanacheServer).close();
 }


### PR DESCRIPTION
This problem exacerbated by our `GanacheServer` not clearing up after itself. 

The contract address is determined by the deploying account and tx count https://ethereum.stackexchange.com/a/761